### PR TITLE
Bugfixes

### DIFF
--- a/hydrogen.config.js
+++ b/hydrogen.config.js
@@ -1,22 +1,13 @@
-import {CookieSessionStorage, defineConfig} from '@shopify/hydrogen/config';
+import {defineConfig, CookieSessionStorage} from '@shopify/hydrogen/config';
 
 export default defineConfig({
   shopify: {
-    defaultCountryCode: 'US',
-    defaultLanguageCode: 'EN',
-    showQueryTiming: true,
-    storeDomain:
-      // @ts-ignore kitunga-fashion.myshopify.com
-      Oxygen?.env?.PUBLIC_STORE_DOMAIN,
-    storefrontToken:
-      // @ts-ignore Storefront API access token
-      Oxygen?.env?.PUBLIC_STOREFRONT_API_TOKEN,
-    privateStorefrontToken:
-      // @ts-ignore Admin API access token
-      Oxygen?.env?.PRIVATE_STOREFRONT_API_TOKEN,
+    defaultCountry: 'US',
+    defaultLanguage: 'EN',
+    defaultLocale: 'en-US',
+    storeDomain: import.meta.env.PUBLIC_STORE_DOMAIN,
+    storefrontToken: import.meta.env.PUBLIC_STOREFRONT_API_TOKEN,
     storefrontApiVersion: '2022-10',
-    // @ts-ignore
-    storefrontId: Oxygen?.env?.PUBLIC_STOREFRONT_ID,
   },
   session: CookieSessionStorage('__session', {
     path: '/',

--- a/index.html
+++ b/index.html
@@ -10,8 +10,11 @@
     <link rel="stylesheet" href="/src/styles/images.css" />
     <link rel="preconnect" href="https://cdn.shopify.com" />
     <link rel="preconnect" href="https://shop.app/" />
+    <!--
+      This reference isn't needed anymore and could be causing issues
     <link rel="preconnect" href="https://hydrogen-preview.myshopify.com/" />
-    <link rel="preconnect" href="https://kitunga-fashion.myshopify.com/" />
+    -->
+   <link rel="preconnect" href="https://kitunga-fashion.myshopify.com/" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
- You need to remove reference to Shopify demo store in _index.html_ I have just commented this out for now so you can do that
- Tidied up _hydrogen.config_ remove oxygen environment and opted for _Vite's import meta_ instead - you can edit these to match your ENV files.

I was able to view all pages and products using one of my clients API credentials, so this **should** work. As I mentioned on Fiverr, if it doesn't we will need to look at the Storefront API set up within Shopify to make sure all the correct permissions are set. Let me know how you get on!